### PR TITLE
Improves handling of digital objects and API pagination

### DIFF
--- a/aquarius/settings.py
+++ b/aquarius/settings.py
@@ -125,6 +125,12 @@ ARCHIVESSPACE = CF.ARCHIVESSPACE
 URSA_MAJOR = CF.URSA_MAJOR
 AURORA = CF.AURORA
 
+
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 25,
+}
+
 structlog.configure(
     processors=[
         structlog.stdlib.add_logger_name,

--- a/transformer/routines.py
+++ b/transformer/routines.py
@@ -162,7 +162,7 @@ class DigitalObjectRoutine(Routine):
 
     def run(self):
         self.bind_log()
-        packages = Package.objects.filter(process_status=Package.TRANSFER_COMPONENT_CREATED)
+        packages = Package.objects.filter(process_status=Package.TRANSFER_COMPONENT_CREATED).order_by('last_modified')[:2]
         digital_count = 0
 
         for package in packages:

--- a/transformer/views.py
+++ b/transformer/views.py
@@ -47,7 +47,7 @@ class PackageViewSet(ModelViewSet):
             return Response("Error creating package: {}".format(str(e)))
 
     def get_queryset(self):
-        queryset = Package.objects.all()
+        queryset = Package.objects.all().order_by('-last_modified')
         updated_since = self.request.GET.get('updated_since', "")
         if updated_since != "":
             queryset = queryset.filter(last_modified__gte=datetime.fromtimestamp(int(updated_since)))


### PR DESCRIPTION
paginates and orders list views, fixes #53 
Limits number of digital objects created at a time to 2, fixes #52 